### PR TITLE
minimal package manifest and lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "headless-examples",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "headless-examples",
+  "version": "1.0.0",
+  "description": "Examples to support the MDN resource covering Firefox headless mode — see https://developer.mozilla.org/en-US/Firefox/Headless_mode",
+  "main": "selenium-test.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdn/headless-examples.git"
+  },
+  "keywords": [],
+  "author": "Mozilla",
+  "license": "CC0-1.0",
+  "bugs": {
+    "url": "https://github.com/mdn/headless-examples/issues"
+  },
+  "homepage": "https://github.com/mdn/headless-examples#readme"
+}


### PR DESCRIPTION
Adding a package manifest enables users to `npm install` to get any dependencies they need to run the examples.

Note: I specified the [CC0 license](https://wiki.creativecommons.org/wiki/CC0) per the [Mozilla Source Code License Policy](https://www.mozilla.org/en-US/MPL/license-policy/), which states, "Trivial bits of Mozilla Code, such as testcases or snippets of code used in documentation, should be put in the public domain in order to facilitate re-use." Per its web page, the CC0 license replaces the deprecated "Public Domain Dedication and Certification."